### PR TITLE
overwrite CupertinoPicker's default selection overlay

### DIFF
--- a/lib/widget/date_picker_widget.dart
+++ b/lib/widget/date_picker_widget.dart
@@ -192,6 +192,7 @@ class _DatePickerWidgetState extends State<DatePickerWidget> {
               decoration:
                   BoxDecoration(color: widget.pickerTheme!.backgroundColor),
               child: CupertinoPicker(
+                selectionOverlay: Container(),
                 backgroundColor: widget.pickerTheme!.backgroundColor,
                 scrollController: scrollCtrl,
                 squeeze: 0.95,


### PR DESCRIPTION
Removed default CupertinoPicker selection overlay introduced in Flutter 2 to adhere to the original design of holo date picker. Fixes #32.

Note: the `selectionOverlay` property docs say to remove it one can set it to `null`, but there seems to be a [bug in the Flutter framework](https://github.com/flutter/flutter/issues/79196) itself that doesn't allow it when using null safety, so until a fix is rolled out for that issue, we're just going to have to settle for overwriting that property with an empty `Container()`.

Before:
![image](https://user-images.githubusercontent.com/11684367/112722699-f51da780-8f02-11eb-8035-233144616c13.png)

After:
![image](https://user-images.githubusercontent.com/11684367/112722717-08307780-8f03-11eb-91d9-30008f52fb51.png)
