### PR TITLE
Add french case in localeFromString method

### DIFF
--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -70,6 +70,9 @@ class DatePicker {
       case 'nn':
         return DateTimePickerLocale.no_nn;
 
+      case 'fr':
+        return DateTimePickerLocale.fr;
+
       default:
         return DateTimePickerLocale.en_us;
     }


### PR DESCRIPTION
It appears that french support was implemented in `l18n` folder but not linked in `localeFromString` method.

Before :
```dart
print(DatePicker.localeFromString('fr')); // DateTimePickerLocale.en_us
```

After : 
```dart
print(DatePicker.localeFromString('fr')); // DateTimePickerLocale.fr
```