### PR TITLE
Implement dividerHeight and dividerThickness

### DIFF
--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -125,6 +125,8 @@ class DatePicker {
     String? cancelText,
     bool looping: false,
     bool reverse: false,
+    double? spacerHeight,
+    double? spackerThickness,
   }) {
     DateTime? _selectedDate = initialDate;
     final List<Widget> listButtonActions = [
@@ -189,6 +191,8 @@ class DatePicker {
             _selectedDate = date;
           }),
           looping: looping,
+          spacerHeight: spacerHeight,
+          spacerThickness: spackerThickness,
         ),
       ),
       actions:

--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -125,8 +125,8 @@ class DatePicker {
     String? cancelText,
     bool looping: false,
     bool reverse: false,
-    double? spacerHeight,
-    double? spackerThickness,
+    double? dividerHeight,
+    double? dividerThickness,
   }) {
     DateTime? _selectedDate = initialDate;
     final List<Widget> listButtonActions = [
@@ -191,8 +191,8 @@ class DatePicker {
             _selectedDate = date;
           }),
           looping: looping,
-          spacerHeight: spacerHeight,
-          spacerThickness: spackerThickness,
+          dividerHeight: dividerHeight,
+          dividerThickness: dividerThickness,
         ),
       ),
       actions:

--- a/lib/widget/date_picker_widget.dart
+++ b/lib/widget/date_picker_widget.dart
@@ -26,6 +26,8 @@ class DatePickerWidget extends StatefulWidget {
     this.onChange,
     this.onConfirm,
     this.looping: false,
+    this.spacerHeight,
+    this.spacerThickness,
   }) : super(key: key) {
     DateTime minTime = firstDate ?? DateTime.parse(DATE_PICKER_MIN_DATETIME);
     DateTime maxTime = lastDate ?? DateTime.parse(DATE_PICKER_MAX_DATETIME);
@@ -36,6 +38,8 @@ class DatePickerWidget extends StatefulWidget {
   final String? dateFormat;
   final DateTimePickerLocale? locale;
   final DateTimePickerTheme? pickerTheme;
+  final double? spacerHeight;
+  final double? spacerThickness;
 
   final DateVoidCallback? onCancel;
   final DateValueCallback? onChange, onConfirm;
@@ -227,8 +231,8 @@ class _DatePickerWidgetState extends State<DatePickerWidget> {
                       child: Divider(
                         color: widget.pickerTheme!.dividerColor ??
                             widget.pickerTheme!.itemTextStyle.color,
-                        height: 1,
-                        thickness: 2,
+                        height: widget.spacerHeight,
+                        thickness: widget.spacerThickness,
                       ),
                     ),
                     SizedBox(width: MediaQuery.of(context).size.width * 0.02)

--- a/lib/widget/date_picker_widget.dart
+++ b/lib/widget/date_picker_widget.dart
@@ -26,8 +26,8 @@ class DatePickerWidget extends StatefulWidget {
     this.onChange,
     this.onConfirm,
     this.looping: false,
-    this.spacerHeight,
-    this.spacerThickness,
+    this.dividerHeight = 1,
+    this.dividerThickness = 2,
   }) : super(key: key) {
     DateTime minTime = firstDate ?? DateTime.parse(DATE_PICKER_MIN_DATETIME);
     DateTime maxTime = lastDate ?? DateTime.parse(DATE_PICKER_MAX_DATETIME);
@@ -38,8 +38,8 @@ class DatePickerWidget extends StatefulWidget {
   final String? dateFormat;
   final DateTimePickerLocale? locale;
   final DateTimePickerTheme? pickerTheme;
-  final double? spacerHeight;
-  final double? spacerThickness;
+  final double? dividerHeight;
+  final double? dividerThickness;
 
   final DateVoidCallback? onCancel;
   final DateValueCallback? onChange, onConfirm;
@@ -231,8 +231,8 @@ class _DatePickerWidgetState extends State<DatePickerWidget> {
                       child: Divider(
                         color: widget.pickerTheme!.dividerColor ??
                             widget.pickerTheme!.itemTextStyle.color,
-                        height: widget.spacerHeight,
-                        thickness: widget.spacerThickness,
+                        height: widget.dividerHeight,
+                        thickness: widget.dividerThickness,
                       ),
                     ),
                     SizedBox(width: MediaQuery.of(context).size.width * 0.02)

--- a/lib/widget/date_picker_widget.dart
+++ b/lib/widget/date_picker_widget.dart
@@ -250,8 +250,8 @@ class _DatePickerWidgetState extends State<DatePickerWidget> {
                       child: Divider(
                         color: widget.pickerTheme!.dividerColor ??
                             widget.pickerTheme!.itemTextStyle.color,
-                        height: 1,
-                        thickness: 2,
+                        height: widget.dividerHeight,
+                        thickness: widget.dividerThickness,
                       ),
                     ),
                     SizedBox(width: MediaQuery.of(context).size.width * 0.02),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_holo_date_picker
 description: A Flutter package of Datepicker that looks like Holo Theme in Android.
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/kfiross/flutter_holo_date_picker
 
 environment:


### PR DESCRIPTION
## What does this PR do?

Implement dividerHeight and dividerThickness to change the size of dividers.

## Usage

```dart
DatePicker.showSimpleDatePicker(
  context,
  initialDate: DateTime(1994),
  firstDate: DateTime(1960),
  dateFormat: "dd-MMMM-yyyy",
  dividerHeight: 1.0,
  dividerThickness: 1.0,
);
```