### PR TITLE
It is now possible to use transparent background colors

### DIFF
--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -182,7 +182,7 @@ class DatePicker {
           dateFormat: dateFormat,
           locale: locale,
           pickerTheme: DateTimePickerTheme(
-            backgroundColor: backgroundColor,
+            backgroundColor: Colors.transparent,
             itemTextStyle: itemTextStyle ?? TextStyle(color: textColor),
           ),
           onChange: ((DateTime date, list) {


### PR DESCRIPTION
Now the transparent background is displayed correctly.

Before:
![Screenshot 2024-11-20 200324](https://github.com/user-attachments/assets/5664e671-9f37-4aa9-9bec-8f09a3382a85)

After:
![Screenshot 2024-11-20 201912](https://github.com/user-attachments/assets/5761d623-3b78-4481-9612-aac8b94b1478)


