### PR TITLE
Added ability to set barrierColor

### DIFF
--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -120,6 +120,7 @@ class DatePicker {
     DateTimePickerMode pickerMode = DateTimePickerMode.date,
     Color? backgroundColor,
     Color? textColor,
+    Color? barrierColor,
     TextStyle? itemTextStyle,
     String? titleText,
     String? confirmText,
@@ -196,6 +197,7 @@ class DatePicker {
           reverse ? listButtonActions.reversed.toList() : listButtonActions,
     );
     return showDialog(
+        barrierColor: barrierColor,
         useRootNavigator: false,
         context: context,
         builder: (context) => datePickerDialog);


### PR DESCRIPTION
The color to use for the modal barrier. 
The modal barrier is the scrim that is rendered behind each route, which generally prevents the user from interacting with the route below the current route, and normally partially obscures such routes.
https://api.flutter.dev/flutter/widgets/ModalRoute/barrierColor.html