### PR TITLE
Add support for common Egyptian Arabic month names

### DIFF
--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/lib/date_picker.dart
+++ b/lib/date_picker.dart
@@ -20,6 +20,9 @@ class DatePicker {
   /// languageCode: [languageCode] Locale's String language code
   static DateTimePickerLocale localeFromString(String languageCode) {
     switch (languageCode) {
+
+      case 'ar_EG':
+        return DateTimePickerLocale.ar_EG;
       case 'zh':
         return DateTimePickerLocale.zh_cn;
 

--- a/lib/i18n/date_picker_i18n.dart
+++ b/lib/i18n/date_picker_i18n.dart
@@ -166,6 +166,7 @@ const DateTimePickerLocale DATETIME_PICKER_LOCALE_DEFAULT =
     DateTimePickerLocale.en_us;
 
 const Map<DateTimePickerLocale, _StringsI18n> datePickerI18n = {
+  DateTimePickerLocale.ar_EG: const _StringsArEg(),
   DateTimePickerLocale.en_us: const _StringsEnUs(),
   DateTimePickerLocale.zh_cn: const _StringsZhCn(),
   DateTimePickerLocale.pt_br: const _StringsPtBr(),

--- a/lib/i18n/date_picker_i18n.dart
+++ b/lib/i18n/date_picker_i18n.dart
@@ -163,7 +163,7 @@ enum DateTimePickerLocale {
 
 /// Default value of date locale
 const DateTimePickerLocale DATETIME_PICKER_LOCALE_DEFAULT =
-    DateTimePickerLocale.en_us;
+    DateTimePickerLocale.ar_EG;
 
 const Map<DateTimePickerLocale, _StringsI18n> datePickerI18n = {
   DateTimePickerLocale.ar_EG: const _StringsArEg(),

--- a/lib/i18n/date_picker_i18n.dart
+++ b/lib/i18n/date_picker_i18n.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+part 'string_ar_eg.dart';
+
 part 'strings_ar.dart';
 
 part 'strings_bn.dart';
@@ -74,6 +76,9 @@ abstract class _StringsI18n {
 }
 
 enum DateTimePickerLocale {
+  /// Arabic (AR) Egypt
+  ar_EG,
+
   /// English (EN) United States
   en_us,
 
@@ -226,7 +231,8 @@ class DatePickerI18n {
       if (weeks.isNotEmpty) {
         return weeks;
       }
-      return datePickerI18n[DATETIME_PICKER_LOCALE_DEFAULT]!.getWeeksFull();
+      return datePickerI18n[DATETIME_PICKER_LOCALE_DEFAULT]!
+          .getWeeksFull();
     }
 
     List<String>? weeks = i18n!.getWeeksShort();

--- a/lib/i18n/date_picker_i18n.dart
+++ b/lib/i18n/date_picker_i18n.dart
@@ -163,7 +163,7 @@ enum DateTimePickerLocale {
 
 /// Default value of date locale
 const DateTimePickerLocale DATETIME_PICKER_LOCALE_DEFAULT =
-    DateTimePickerLocale.ar_EG;
+    DateTimePickerLocale.en_us;
 
 const Map<DateTimePickerLocale, _StringsI18n> datePickerI18n = {
   DateTimePickerLocale.ar_EG: const _StringsArEg(),

--- a/lib/i18n/string_ar_eg.dart
+++ b/lib/i18n/string_ar_eg.dart
@@ -1,0 +1,52 @@
+part of 'date_picker_i18n.dart';
+
+/// Arabic (AR)
+class _StringsArEg extends _StringsI18n {
+  const _StringsArEg();
+
+  @override
+  String getCancelText() {
+    return 'ألغاء';
+  }
+
+  @override
+  String getDoneText() {
+    return 'تم';
+  }
+
+  @override
+  List<String> getMonths() {
+    return [
+      "يناير",
+      "فبراير",
+      "مارس",
+      "أبريل",
+      "مايو",
+      "يونيو",
+      "يوليو",
+      "أغسطس",
+      "سبتمبر",
+      "أكتوبر",
+      "نوفمبر",
+      "ديسمبر",
+    ];
+  }
+
+  @override
+  List<String> getWeeksFull() {
+    return [
+      "الأثنين",
+      "الثلاثاء",
+      "الأربعاء",
+      "الخميس",
+      "الجمعه",
+      "السبت",
+      "الأحد",
+    ];
+  }
+
+  @override
+  List<String>? getWeeksShort() {
+    return null;
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds support for Egyptian Arabic (ar-EG) month names to the flutter_holo_date_picker package. 
It enables the date picker to display months in a format commonly used in Egypt.

### Changes
- Added a new list of months in Egyptian Arabic:
  - "يناير", "فبراير", "مارس", "أبريل", "مايو", "يونيو",
    "يوليو", "أغسطس", "سبتمبر", "أكتوبر", "نوفمبر", "ديسمبر"
- Updated locale mapping to include `ar-EG`
- Ensures backward compatibility with existing Arabic (`ar`) locale

### Usage Hint
To display the **full month name** in Egyptian Arabic, set the date format as follows:
```dart
dateFormat: "yyyy-MMMM-dd",
